### PR TITLE
Configuration to skip writing checkpoint to hudi, this will force it …

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -698,10 +698,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (checkpointStr != null) {
+      if (cfg.checkpointWriteToHoodie && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (cfg.checkpoint != null) {
+      if (cfg.checkpointWriteToHoodie && cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -698,10 +698,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (cfg.checkpointWriteToHoodie && checkpointStr != null) {
+      if (!cfg.disableCheckpointWriteToHoodie && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (cfg.checkpointWriteToHoodie && cfg.checkpoint != null) {
+      if (!cfg.disableCheckpointWriteToHoodie && cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -424,7 +424,9 @@ public class DeltaSync implements Serializable, Closeable {
     // Retrieve the previous round checkpoints, if any
     Option<String> resumeCheckpointStr = Option.empty();
     if (commitTimelineOpt.isPresent()) {
-      resumeCheckpointStr = getCheckpointToResume(commitTimelineOpt);
+      if (!cfg.disableHoodieTimelineCheckpoint) {
+        resumeCheckpointStr = getCheckpointToResume(commitTimelineOpt);
+      }
     } else {
       // initialize the table for the first time.
       String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props);
@@ -698,10 +700,10 @@ public class DeltaSync implements Serializable, Closeable {
     boolean hasErrors = totalErrorRecords > 0;
     if (!hasErrors || cfg.commitOnErrors) {
       HashMap<String, String> checkpointCommitMetadata = new HashMap<>();
-      if (!cfg.disableCheckpointWriteToHoodie && checkpointStr != null) {
+      if (!cfg.disableHoodieTimelineCheckpoint && checkpointStr != null) {
         checkpointCommitMetadata.put(CHECKPOINT_KEY, checkpointStr);
       }
-      if (!cfg.disableCheckpointWriteToHoodie && cfg.checkpoint != null) {
+      if (cfg.checkpoint != null) {
         checkpointCommitMetadata.put(CHECKPOINT_RESET_KEY, cfg.checkpoint);
       }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,8 +373,9 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
-    @Parameter(names = {"--disable-checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
-    public Boolean disableCheckpointWriteToHoodie = false;
+    @Parameter(names = {"--disable-hoodie-commit-checkpoint"}, description = "Disable reading checkpoint from " +
+            ".hoodie commit timeline and do not write checkpoint to .hoodie commit timeline")
+    public Boolean disableHoodieTimelineCheckpoint = false;
 
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,6 +373,9 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
+    @Parameter(names = {"--checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
+    public boolean checkpointWriteToHoodie = true;
+
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "
         + "for the first run. This field will override the checkpoint of last commit using the checkpoint field. "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -373,8 +373,8 @@ public class HoodieDeltaStreamer implements Serializable {
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
 
-    @Parameter(names = {"--checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
-    public boolean checkpointWriteToHoodie = true;
+    @Parameter(names = {"--disable-checkpoint-write-to-hoodie"}, description = "Write checkpoint to .hoodie")
+    public Boolean disableCheckpointWriteToHoodie = false;
 
     @Parameter(names = {"--initial-checkpoint-provider"}, description = "subclass of "
         + "org.apache.hudi.utilities.checkpointing.InitialCheckpointProvider. Generate check point for delta streamer "

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -476,7 +476,7 @@ public class KafkaOffsetGen {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
         LOG.warn("There are no commits associated with this consumer group, starting to consume from latest offset");
-        fromOffsets = consumer.endOffsets(topicPartitions);
+        fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }
     }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -476,6 +476,8 @@ public class KafkaOffsetGen {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
         LOG.warn("There are no commits associated with this consumer group, starting to consume from earliest offset");
+        // Fetching the offset from the beginning will be done only for the first time.
+        // When the offsets are not yet committed to Kafka.
         fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaOffsetGen.java
@@ -475,7 +475,7 @@ public class KafkaOffsetGen {
       if (committedOffsetAndMetadata != null) {
         fromOffsets.put(topicPartition, committedOffsetAndMetadata.offset());
       } else {
-        LOG.warn("There are no commits associated with this consumer group, starting to consume from latest offset");
+        LOG.warn("There are no commits associated with this consumer group, starting to consume from earliest offset");
         fromOffsets = consumer.beginningOffsets(topicPartitions);
         break;
       }


### PR DESCRIPTION
Configuration to skip writing checkpoint to hudi, this will force it to read the checkpoint from other sources. We can set `auto.offset.reset=group` to ask it to read from the Kafka commit.

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
